### PR TITLE
fix(post/useSend): memo cannot include angle brackets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@terra-money/use-station",
   "author": "Terra <engineering@terra.money> (https://terra.money)",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "main": "dist/index.js",
   "module": "dist/use-station.esm.js",
   "typings": "dist/index.d.ts",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -66,6 +66,7 @@
       "{{label}} must be between {{min}} and {{max}} characters": "{{label}} doit être compris entre {{min}} et {{max}} caractères",
       "{{label}} must be longer than {{min}} characters": "{{label}} doit être plus long que {{min}} caractères",
       "{{label}} must be within 6 decimal points": "{{label}} doit être compris entre 6 points décimaux",
+      "{{label}} cannot include angle brackets": "{{label}} ne peut pas inclure le caractère",
       "Password does not match": "Le mot de passe ne correspond pas",
       "Insufficient balance": "Solde insuffisant",
       "Invalid": "Invalide"

--- a/src/lang/ko.json
+++ b/src/lang/ko.json
@@ -66,6 +66,7 @@
       "{{label}} must be between {{min}} and {{max}} characters": "{{label}}은(는) {{min}}자 이상 {{max}}자 이하여야 합니다",
       "{{label}} must be longer than {{min}} characters": "{{label}}는 {{min}}자보다 길어야 합니다",
       "{{label}} must be within 6 decimal points": "{{label}}은(는) 소수점 6자리 이내여야 합니다",
+      "{{label}} cannot include angle brackets": "{{label}}에 꺾쇠 괄호 문자를 사용할 수 없습니다",
       "Password does not match": "비밀번호가 일치하지 않습니다",
       "Insufficient balance": "잔액이 부족합니다",
       "Invalid": "유효하지 않습니다"

--- a/src/lang/zh.json
+++ b/src/lang/zh.json
@@ -66,6 +66,7 @@
       "{{label}} must be between {{min}} and {{max}} characters": "{{label}}必须至少{{min}}个且不超过{{max}}个字符",
       "{{label}} must be longer than {{min}} characters": "{{label}}必须大于{{min}}个字符",
       "{{label}} must be within 6 decimal points": "{{label}}必须在6位小数位之内。",
+      "{{label}} cannot include angle brackets": "{{label}}不能使用歪斜括号文字",
       "Password does not match": "密码不匹配",
       "Insufficient balance": "余额不足",
       "Invalid": "无效"

--- a/src/post/useSend.ts
+++ b/src/post/useSend.ts
@@ -103,7 +103,10 @@ export default (user: User, denom: string): PostPage<RecentSentUI> => {
   const validate = ({ input, to, memo }: Values) => ({
     to: v.address(to),
     input: v.input(input, { max: toInput(max.amount) }),
-    memo: v.length(memo, { max: 256, label: t('Common:Tx:Memo') })
+    memo:
+      v.length(memo, { max: 256, label: t('Common:Tx:Memo') }) ||
+      v.includes(memo, '<') ||
+      v.includes(memo, '>')
   })
 
   const initial = { to: '', input: '', memo: '' }

--- a/src/post/validateForm.ts
+++ b/src/post/validateForm.ts
@@ -56,6 +56,13 @@ const validateForm = (t: TFunction) => {
     length: (text: string, { max, label }: { max: number; label: string }) =>
       new Blob([text]).size > max
         ? t('Common:Validate:{{label}} is too long', { label })
+        : '',
+
+    includes: (haystack: string, needle: string): string =>
+      haystack.includes(needle)
+        ? t('Common:Validate:{{label}} cannot include angle brackets', {
+            label: t('Common:Tx:Memo')
+          })
         : ''
   }
 }


### PR DESCRIPTION
## Description
This PR validates memo to not have < or > character (angle brackets) which leads tx to be verification fail 🤮