### PR TITLE
fix: Handle timezone miss-match in different location than seoul

### DIFF
--- a/src/pages/dashboard/datetime.ts
+++ b/src/pages/dashboard/datetime.ts
@@ -1,0 +1,7 @@
+import { DateTime } from 'luxon'
+
+// Fix the timezone miss-match issue on the mainnet
+export const fix = (datetime: number): Date =>
+  DateTime.fromMillis(datetime)
+    .plus({ hour: 9 })
+    .toJSDate()

--- a/src/pages/dashboard/getStakingReturn.ts
+++ b/src/pages/dashboard/getStakingReturn.ts
@@ -2,6 +2,7 @@ import { TFunction } from 'i18next'
 import { CumulativeType } from '../../types'
 import { percent, toNumber, times, format } from '../../utils'
 import { Props } from './useChartCard'
+import { fix } from './datetime'
 
 interface Result {
   datetime: number
@@ -35,13 +36,13 @@ export default (t: TFunction): Props<Result> => ({
     return {
       data:
         results?.map(({ datetime, ...rest }) => ({
-          t: new Date(datetime),
+          t: fix(datetime),
           y: toNumber(times(rest[key], 100))
         })) ?? [],
       tooltips:
         results?.map(({ datetime, ...rest }) => ({
           title: percent(rest[key]),
-          label: format.date(new Date(datetime), { short: true })
+          label: format.date(fix(datetime), { short: true })
         })) ?? []
     }
   }

--- a/src/pages/dashboard/getTaxRewards.ts
+++ b/src/pages/dashboard/getTaxRewards.ts
@@ -2,6 +2,7 @@ import { TFunction } from 'i18next'
 import { CumulativeType, Currency } from '../../types'
 import { format, sum, minus, times } from '../../utils'
 import { Props } from './useChartCard'
+import { fix } from './datetime'
 
 interface Result {
   datetime: number
@@ -36,7 +37,7 @@ export default (
     getChart: results => ({
       data:
         results?.map(({ datetime, blockReward }) => ({
-          t: new Date(datetime),
+          t: fix(datetime),
           y: format.amountN(exchange(blockReward))
         })) ?? [],
       tooltips:
@@ -45,7 +46,7 @@ export default (
             { amount: exchange(blockReward), denom },
             { integer: true }
           ),
-          label: format.date(new Date(datetime), { short: true })
+          label: format.date(fix(datetime), { short: true })
         })) ?? []
     })
   }

--- a/src/pages/dashboard/getTotalAccounts.ts
+++ b/src/pages/dashboard/getTotalAccounts.ts
@@ -2,6 +2,7 @@ import { TFunction } from 'i18next'
 import { CumulativeType, AccountType } from '../../types'
 import { format } from '../../utils'
 import { Props } from './useChartCard'
+import { fix } from './datetime'
 
 interface Result {
   datetime: number
@@ -28,13 +29,13 @@ export default (t: TFunction): Props<Result> => ({
   getChart: results => ({
     data:
       results?.map(({ datetime, value }) => ({
-        t: new Date(datetime),
+        t: fix(datetime),
         y: value
       })) ?? [],
     tooltips:
       results?.map(({ datetime, value }) => ({
         title: format.decimal(String(value), 0),
-        label: format.date(new Date(datetime), { short: true })
+        label: format.date(fix(datetime), { short: true })
       })) ?? []
   })
 })

--- a/src/pages/dashboard/getTxVolume.ts
+++ b/src/pages/dashboard/getTxVolume.ts
@@ -2,6 +2,7 @@ import { TFunction } from 'i18next'
 import { CumulativeType } from '../../types'
 import { format, sum, minus } from '../../utils'
 import { Props } from './useChartCard'
+import { fix } from './datetime'
 
 interface Result {
   denom: string
@@ -45,10 +46,11 @@ export default (t: TFunction): Props<Result> => ({
   },
   getChart: (results, { denom }) => {
     const result = results.find(r => r.denom === denom)
+
     return {
       data:
         result?.data.map(({ datetime, txVolume }) => ({
-          t: new Date(datetime),
+          t: fix(datetime),
           y: format.amountN(txVolume)
         })) ?? [],
       tooltips:
@@ -57,7 +59,7 @@ export default (t: TFunction): Props<Result> => ({
             { amount: txVolume, denom: result.denom },
             { integer: true }
           ),
-          label: format.date(new Date(datetime), { short: true })
+          label: format.date(fix(datetime), { short: true })
         })) ?? []
     }
   }


### PR DESCRIPTION
Timezone miss-match reason is 'datetime' of the chart data, and after adding 9 hours, it worked.